### PR TITLE
6 - Avoid double runs for gh actions

### DIFF
--- a/.github/workflows/format-and-lint.yml
+++ b/.github/workflows/format-and-lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18]
+        node-version: [23]
     steps:
       - name: Check out branch (pull request)
         uses: actions/checkout@v4

--- a/.github/workflows/format-and-lint.yml
+++ b/.github/workflows/format-and-lint.yml
@@ -8,6 +8,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   lint:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.repository != github.event.pull_request.head.repo.full_name)
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Closes #6

This change should ensure the following happens:
 - On any push to branches within this repo, the format-and-lint action runs.
 - The format-and-lint action only runs on pull_request events when that pull request is from a forked repo, ensuring that we don't have double runs on every single push.
 
 For this PR, you can see that the pull_request job is skipped
 
![image](https://github.com/user-attachments/assets/f8075679-9fe6-4c13-89ac-a6c44b30451d)

As can be seen in #12, only the pull_request events trigger the action when it is from a forked repo
![image](https://github.com/user-attachments/assets/eb707cac-d537-471c-b73b-00239cf91aef)


