### PR TITLE
Update format-and-lint.yml to use nvmrc

### DIFF
--- a/.github/workflows/format-and-lint.yml
+++ b/.github/workflows/format-and-lint.yml
@@ -10,16 +10,14 @@ jobs:
   lint:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.repository != github.event.pull_request.head.repo.full_name)
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [23]
     steps:
       - name: Check out branch (pull request)
         uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: .nvmrc
+          cache: "npm"
       - name: Install packages
         run: npm ci
       - name: Check Formatting with Prettier


### PR DESCRIPTION
## What issue is this solving?

Closes #24 

### Description

Brings the format and lint workflow in line with the deploy (and new TS check in #23 ) workflows to use the Node version specified in `.nvmrc` instead of specifying v23.

## Any helpful knowledge/context for the reviewer?

- Any new dependencies to install? ❌ 
- Any special requirements to test? ❌ 
- Any UI changes? Include screenshots if so. ❌ 

### Please make sure you've attempted to meet the following coding standards

- [x] Code has been tested and does not produce errors
- [x] Code is readable and formatted
- [x] There isn't any unnecessary commented-out code
